### PR TITLE
64-bit NDK Support

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -145,16 +145,16 @@ fi
 # Check platform patch
 case "$HOST_OS" in
     linux)
-        Platfrom=linux-x86
+        Platfrom=linux-$HOST_ARCH
         ;;
     darwin|freebsd)
-        Platfrom=darwin-x86
+        Platfrom=darwin-$HOST_ARCH
         ;;
     windows|cygwin)
-        Platfrom=windows-x86
+        Platfrom=windows-$HOST_ARCH
         ;;
     *)  # let's play safe here
-        Platfrom=linux-x86
+        Platfrom=linux-$HOST_ARCH
 esac
 
 NDK_RELEASE_FILE=$AndroidNDKRoot"/RELEASE.TXT"
@@ -184,7 +184,7 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/arm-linux-androideabi-4.6/prebuilt/$Platfrom/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8b
 		;;
-	8e)
+	8e|"8e (64-bit)")
 		CXXPATH=$AndroidNDKRoot/toolchains/arm-linux-androideabi-4.6/prebuilt/$Platfrom/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8e
 		;;

--- a/build-common.sh
+++ b/build-common.sh
@@ -133,7 +133,7 @@ HOST_ARCH=`uname -m`
 case "$HOST_ARCH" in
     i?86) HOST_ARCH=x86
     ;;
-    amd64) HOST_ARCH=x86_64
+    amd64|x86_64) HOST_ARCH=x86_64
     ;;
     powerpc) HOST_ARCH=ppc
     ;;


### PR DESCRIPTION
NDK r8e has a 64-bit toolchain available, so I updated the scripts to handle that nicely.

One change was to recognize 'x86_64' as well as 'amd64' when determining `$HOST_ARCH`. The net was to create the platform names as `[value]-$HOST_ARCH` instead of hardcoding `-x86`. The last change was to recognize a toolset name with a `(64-bit)` suffix, although only for NDK r8e. I'm sure a more experienced shell-coding hand than mine can improve on my simple OR statement for that though…
