### PR TITLE
Add env variable __ANDROID__ to conditions

### DIFF
--- a/patches/boost-1_53_0/boost-1_53_0.patch
+++ b/patches/boost-1_53_0/boost-1_53_0.patch
@@ -68,7 +68,7 @@ diff -ruN boost_1_53_0-boot/boost/detail/endian.hpp boost_1_53_0-patched/boost/d
  // __BYTE_ORDER
  
 -#if defined (__GLIBC__)
-+#if defined (__GLIBC__) || defined(ANDROID)
++#if defined (__GLIBC__) || defined(ANDROID) || defined(__ANDROID__)
  # include <endian.h>
  # if (__BYTE_ORDER == __LITTLE_ENDIAN)
  #  define BOOST_LITTLE_ENDIAN
@@ -80,7 +80,7 @@ diff -ruN boost_1_53_0-boot/boost/interprocess/detail/workaround.hpp boost_1_53_
  
     //Check for XSI shared memory objects. They are available in nearly all UNIX platforms
 -   #if !defined(__QNXNTO__)
-+   #if !defined(__QNXNTO__) && !defined(ANDROID)
++   #if !defined(__QNXNTO__) && !defined(ANDROID) && !defined(__ANDROID_)
        #define BOOST_INTERPROCESS_XSI_SHARED_MEMORY_OBJECTS
     #endif
  


### PR DESCRIPTION
At least in my enviroment the correct variable for Android is "**ANDROID**". For some reason you have both in some places but not in other. This PR adds "**ANDROID**" to those that were missing it.
