### PR TITLE
Fix typo in variable __ANDROID__

### DIFF
--- a/patches/boost-1_53_0/boost-1_53_0.patch
+++ b/patches/boost-1_53_0/boost-1_53_0.patch
@@ -80,7 +80,7 @@ diff -ruN boost_1_53_0-boot/boost/interprocess/detail/workaround.hpp boost_1_53_
  
     //Check for XSI shared memory objects. They are available in nearly all UNIX platforms
 -   #if !defined(__QNXNTO__)
-+   #if !defined(__QNXNTO__) && !defined(ANDROID) && !defined(__ANDROID_)
++   #if !defined(__QNXNTO__) && !defined(ANDROID) && !defined(__ANDROID__)
        #define BOOST_INTERPROCESS_XSI_SHARED_MEMORY_OBJECTS
     #endif
  


### PR DESCRIPTION
Sorry for that, noticed while compiling today...
