### PR TITLE
NDK R9 64 bits support and usage of latest Android NDK tools

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -191,7 +191,7 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/arm-linux-androideabi-4.6/prebuilt/$PlatformOS-x86/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8b
 		;;
-	8e|9*)
+	8e)
 		CXXPATH=$AndroidNDKRoot/toolchains/arm-linux-androideabi-4.6/prebuilt/$PlatformOS-x86/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8e
 		;;
@@ -199,6 +199,14 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/arm-linux-androideabi-4.6/prebuilt/${PlatformOS}-x86_64/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8e
 		;;
+  9)
+    CXXPATH=$AndroidNDKRoot/toolchains/arm-linux-androideabi-4.8/prebuilt/$PlatformOS-x86/bin/arm-linux-androideabi-g++
+    TOOLSET=gcc-androidR9
+    ;;
+  "9 (64-bit)")
+    CXXPATH=$AndroidNDKRoot/toolchains/arm-linux-androideabi-4.8/prebuilt/${PlatformOS}-x86_64/bin/arm-linux-androideabi-g++
+    TOOLSET=gcc-androidR9
+    ;;
 	*)
 		echo "Undefined or not supported Android NDK version!"
 		exit 1

--- a/configs/user-config-boost-1_53_0.jam
+++ b/configs/user-config-boost-1_53_0.jam
@@ -127,6 +127,47 @@ arm-linux-androideabi-g++
 <cxxflags>-D_GLIBCXX__PTHREADS
 ;
 
+# --------------------------------------------------------------------
+using gcc : androidR9
+:
+arm-linux-androideabi-g++
+:
+<archiver>arm-linux-androideabi-ar
+<compileflags>-fexceptions
+<compileflags>-frtti
+<compileflags>-fpic
+<compileflags>-ffunction-sections
+<compileflags>-funwind-tables
+<compileflags>-D__ARM_ARCH_5__
+<compileflags>-D__ARM_ARCH_5T__
+<compileflags>-D__ARM_ARCH_5E__
+<compileflags>-D__ARM_ARCH_5TE__
+<compileflags>-Wno-psabi
+<compileflags>-march=armv5te
+<compileflags>-mtune=xscale
+<compileflags>-msoft-float
+<compileflags>-mthumb
+<compileflags>-Os
+<compileflags>-fomit-frame-pointer
+<compileflags>-fno-strict-aliasing
+<compileflags>-finline-limit=64
+<compileflags>-I$(AndroidNDKRoot)/platforms/android-14/arch-arm/usr/include
+<compileflags>-Wa,--noexecstack
+<compileflags>-DANDROID
+<compileflags>-D__ANDROID__
+<compileflags>-DNDEBUG
+<compileflags>-O2
+<compileflags>-I$(AndroidNDKRoot)/sources/cxx-stl/gnu-libstdc++/4.8/include
+<compileflags>-I$(AndroidNDKRoot)/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi/include
+# @Moss - Above are the 'oficial' android flags
+<architecture>arm
+<compileflags>-fvisibility=hidden
+<compileflags>-fvisibility-inlines-hidden
+<compileflags>-fdata-sections
+<cxxflags>-D__arm__
+<cxxflags>-D_REENTRANT
+<cxxflags>-D_GLIBCXX__PTHREADS
+;
 
 # ------------------
 # GCC configuration.


### PR DESCRIPTION
- Added support for NDK R9 64 bits.
- Added new config to build with NDK R9: use latest supported gcc toolchain (4.8 at this time), target Android API level 14 (was previously 9) and no debug symbol (removed -g flag).
