### PR TITLE
Add support for building boost using ndk provided in Android sources

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -185,8 +185,11 @@ NDK_RELEASE_FILE=$AndroidNDKRoot"/RELEASE.TXT"
 if [ -f "${NDK_RELEASE_FILE}" ]; then
     NDK_RN=`cat $NDK_RELEASE_FILE | sed 's/^r\(.*\)$/\1/g'`
 elif [ -n "${AndroidSourcesDetected}" ]; then
-    NDK_RELEASE_FILE="${ANDROID_BUILD_TOP}/ndk/docs/CHANGES.html"
-    if [ -f "${NDK_RELEASE_FILE}" ]; then
+    if [ -f "${ANDROID_BUILD_TOP}/ndk/docs/CHANGES.html" ]; then
+        NDK_RELEASE_FILE="${ANDROID_BUILD_TOP}/ndk/docs/CHANGES.html"
+        NDK_RN=`grep "android-ndk-" "${NDK_RELEASE_FILE}" | head -1 | sed 's/^.*r\(.*\)$/\1/'`
+    elif [ -f "${ANDROID_BUILD_TOP}/ndk/docs/text/CHANGES.text" ]; then
+        NDK_RELEASE_FILE="${ANDROID_BUILD_TOP}/ndk/docs/text/CHANGES.text"
         NDK_RN=`grep "android-ndk-" "${NDK_RELEASE_FILE}" | head -1 | sed 's/^.*r\(.*\)$/\1/'`
     else
         dump "ERROR: can not find ndk version"


### PR DESCRIPTION
Add possibility to build boost for android when building android source code. 

Android source code has it's own NDK tree organization different from "official" NDK.

Now when build-android.sh is called without parameters it checks if ANDROID_BUILD_TOP exists (from android sources build system). If this variable exists it set a flag "AndroidSourcesDetected".

When flag AndroidSourcesDetected is set:
- NDK version is detected based on "${ANDROID_BUILD_TOP}/ndk/docs/CHANGES.html" as RELEASE.TXT does not exists
- CXXPATH is overwriten to "${ANDROID_TOOLCHAIN}/arm-linux-androideabi-g++". (ANDROID_TOOLCHAIN comes from android sources build system)
