### PR TITLE
Remove hardcoded __arm__ preprocessor definition

### DIFF
--- a/patches/boost-1_55_0/boost-1_55_0.patch
+++ b/patches/boost-1_55_0/boost-1_55_0.patch
@@ -49,7 +49,6 @@ diff -u -r boost_1_55_0/boost/config/user.hpp boost_1_55_0.patched/boost/config/
  //
  
 +// Android defines
-+#define __arm__ 1
 +#define _REENTRANT 1
 +#define _GLIBCXX__PTHREADS 1
 +// There is problem with std::atomic on android (and some other platforms).


### PR DESCRIPTION
I'm not sure why **arm** must be defined to 1 in this patch, the
compiler should internally define architecture flags such as this.
Also this patch causes big problems when building on x86 Android,
as some libraries (notably Google Breakpad, but probably others)
include boost headers and then erroneously believe that they are
both ARM and x86.
