### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*        text=auto
+*.sh     eol=lf


### PR DESCRIPTION
Mainly added to force LF in *.sh files, even on Windows. Scripts will not run properly on Windows because the scripts will use CRLF.
