### PR TITLE
support for building with NDK r10 (32-bit version)

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -242,7 +242,7 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/$PlatformOS-x86/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8b
 		;;
-	8e|9|9b|9c|9d)
+	8e|9|9b|9c|9d|10)
 		TOOLCHAIN=${TOOLCHAIN:-arm-linux-androideabi-4.6}
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/$PlatformOS-x86/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8e


### PR DESCRIPTION
I have NDK r10 installed on 32-bit Linux and instead of successful compilation got a strange message:

Building boost version: 1.53.0
Detected Android NDK version 10
Undefined or not supported Android NDK version!

This patch is supposedly fixed missing detection of NDK r10 on 32-bit machines.
