### PR TITLE
boost 1.67: fix android < 21 error where pthread_condattr_setclock is Called When Method is Only Avaliable in Android >= 21

### DIFF
--- a/patches/boost-1_67_0/boost-1_67_0.patch
+++ b/patches/boost-1_67_0/boost-1_67_0.patch
@@ -1,10 +1,10 @@
 diff -u -r boost_1_67_0.orig/boost/config/user.hpp boost_1_67_0/boost/config/user.hpp
---- boost_1_67_0.orig/boost/config/user.hpp 2018-04-11 15:49:01.000000000 +0200
-+++ boost_1_67_0/boost/config/user.hpp  2018-04-18 11:15:19.000000000 +0200
+--- boost_1_67_0.orig/boost/config/user.hpp	2018-04-27 17:32:47.000000000 -0400
++++ boost_1_67_0/boost/config/user.hpp	2018-04-27 17:34:24.000000000 -0400
 @@ -13,6 +13,12 @@
  //  configuration policy:
  //
-
+ 
 +// Android defines
 +// There is problem with std::atomic on android (and some other platforms).
 +// See this link for more info:
@@ -15,8 +15,8 @@ diff -u -r boost_1_67_0.orig/boost/config/user.hpp boost_1_67_0/boost/config/use
  // #define BOOST_COMPILER_CONFIG <myheader>
  
 diff -u -r boost_1_67_0.orig/boost/system/error_code.hpp boost_1_67_0/boost/system/error_code.hpp
---- boost_1_67_0.orig/boost/system/error_code.hpp   2018-04-11 15:49:08.000000000 +0200
-+++ boost_1_67_0/boost/system/error_code.hpp    2018-04-18 11:16:59.000000000 +0200
+--- boost_1_67_0.orig/boost/system/error_code.hpp	2018-04-27 17:32:49.000000000 -0400
++++ boost_1_67_0/boost/system/error_code.hpp	2018-04-27 17:34:24.000000000 -0400
 @@ -17,6 +17,7 @@
  #include <boost/assert.hpp>
  #include <boost/noncopyable.hpp>
@@ -25,13 +25,28 @@ diff -u -r boost_1_67_0.orig/boost/system/error_code.hpp boost_1_67_0/boost/syst
  #include <ostream>
  #include <string>
  #include <stdexcept>
+diff -u -r boost_1_67_0.orig/boost/thread/detail/config.hpp boost_1_67_0/boost/thread/detail/config.hpp
+--- boost_1_67_0.orig/boost/thread/detail/config.hpp	2018-04-27 17:32:52.000000000 -0400
++++ boost_1_67_0/boost/thread/detail/config.hpp	2018-04-27 17:36:44.000000000 -0400
+@@ -417,6 +417,11 @@
+   #define BOOST_THREAD_INTERNAL_CLOCK_IS_MONO
+ #elif defined(BOOST_THREAD_CHRONO_MAC_API)
+   #define BOOST_THREAD_HAS_MONO_CLOCK
++#elif defined(__ANDROID__)
++  #define BOOST_THREAD_HAS_MONO_CLOCK
++  #if defined(__ANDROID_API__) && __ANDROID_API__ >= 21
++    #define BOOST_THREAD_INTERNAL_CLOCK_IS_MONO
++  #endif
+ #else
+   #include <time.h> // check for CLOCK_MONOTONIC
+   #if defined(CLOCK_MONOTONIC)
 diff -u -r boost_1_67_0.orig/libs/filesystem/src/operations.cpp boost_1_67_0/libs/filesystem/src/operations.cpp
---- boost_1_67_0.orig/libs/filesystem/src/operations.cpp    2018-04-11 15:49:02.000000000 +0200
-+++ boost_1_67_0/libs/filesystem/src/operations.cpp 2018-04-18 11:21:01.000000000 +0200
+--- boost_1_67_0.orig/libs/filesystem/src/operations.cpp	2018-04-27 17:33:02.000000000 -0400
++++ boost_1_67_0/libs/filesystem/src/operations.cpp	2018-04-27 17:34:24.000000000 -0400
 @@ -207,6 +207,21 @@
-
+ 
  # if defined(BOOST_POSIX_API)
-
+ 
 +#  if defined(__ANDROID__)
 +#  define truncate libboost_truncate_wrapper
 +// truncate() is present in Android libc only starting from ABI 21, so here's a simple wrapper
@@ -48,5 +63,5 @@ diff -u -r boost_1_67_0.orig/libs/filesystem/src/operations.cpp boost_1_67_0/lib
 +#  endif
 +
  typedef int err_t;
-
+ 
  //  POSIX uses a 0 return to indicate success


### PR DESCRIPTION
See here: https://github.com/moritz-wundke/Boost-for-Android/issues/132