### PR TITLE
Add Support for NDK r17b

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To compile Boost for Android you may use one of the following NDKs:
 | r8e from the [official android repository](http://developer.android.com).                 |   |   | x | x |   |   |   |
 | r10 from the [official android repository](http://developer.android.com).                 |   |   | x | x |   |   |   |
 | r16 from the [official android repository](http://developer.android.com).                 |   |   |   |   | x | x | x |
+| r17b from the [official android repository](http://developer.android.com).                |   |   |   |   |   |   | x |
 
 # Quick Start
 
@@ -99,3 +100,9 @@ add full path to the gnustl_static library to the link paths. Example:
     LOCAL_LDLIBS += lboost_system-gcc-md lboost_thread-gcc-md \
                  -L$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/libs/armeabi \
                  -lgnustl_static
+
+### NDK 17 (official)
+
+Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed. Attempting to build any of these ABIs will result in an error.
+This project will exclude these architectures for compiling with NDK 17.
+

--- a/build-android.sh
+++ b/build-android.sh
@@ -295,6 +295,11 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
 		;;
+  17.*)
+    TOOLCHAIN=${TOOLCHAIN:-llvm}
+    CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
+    TOOLSET=clang
+    ;;
 	*)
 		echo "Undefined or not supported Android NDK version: $NDK_RN"
 		exit 1
@@ -305,9 +310,17 @@ if [ -n "${AndroidSourcesDetected}" -a "${TOOLSET}" '!=' "clang" ]; then # Overw
 fi
 
 if [ -z "${ARCHLIST}" ]; then
-  ARCHLIST=armeabi
+  ARCHLIST=armeabi-v7a
   if [ "$TOOLSET" = "clang" ]; then
-    ARCHLIST="arm64-v8a armeabi armeabi-v7a mips mips64 x86 x86_64"
+
+    case "$NDK_RN" in
+      # NDK 17: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
+      17.*)
+        ARCHLIST="arm64-v8a armeabi-v7a x86 x86_64"
+        ;;
+      *)
+        ARCHLIST="arm64-v8a armeabi armeabi-v7a mips mips64 x86 x86_64"
+    esac    
   fi
 fi
 


### PR DESCRIPTION
Ich have testet this on macos host. Will successfully build the libraries for armeabi-v7a, arm64-v8a, x86 and x86_64. The architectures armeabi, mips and mips64 are no longer supported by NDK r17.