### PR TITLE
Add Support for NDK r18

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ To compile Boost for Android you may use one of the following NDKs:
 | r8d from the [official android repository](http://developer.android.com).                 |   |   | x | x |   |   |   |   |
 | r8e from the [official android repository](http://developer.android.com).                 |   |   | x | x |   |   |   |   |
 | r10 from the [official android repository](http://developer.android.com).                 |   |   | x | x |   |   |   |   |
-| r16 from the [official android repository](http://developer.android.com).                 |   |   |   |   | x | x | x |   |
+| r16 from the [official android repository](http://developer.android.com).                 |   |   |   |   | x | x | x | x |
 | r17b from the [official android repository](http://developer.android.com).                |   |   |   |   |   |   | x | x |
+| r18 from the [official android repository](http://developer.android.com).                 |   |   |   |   |   |   |   | x |
 
 # Quick Start
 

--- a/build-android.sh
+++ b/build-android.sh
@@ -294,16 +294,11 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8e
 		;;
-	16.*)
+	"16.0"|"16.1"|"17.1"|"18.0")
 		TOOLCHAIN=${TOOLCHAIN:-llvm}
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
 		;;
-  17.*)
-    TOOLCHAIN=${TOOLCHAIN:-llvm}
-    CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
-    TOOLSET=clang
-    ;;
 	*)
 		echo "Undefined or not supported Android NDK version: $NDK_RN"
 		exit 1
@@ -318,8 +313,8 @@ if [ -z "${ARCHLIST}" ]; then
   if [ "$TOOLSET" = "clang" ]; then
 
     case "$NDK_RN" in
-      # NDK 17: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
-      17.*)
+      # NDK 17+: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
+      "17.1"|"18.0")
         ARCHLIST="arm64-v8a armeabi-v7a x86 x86_64"
         ;;
       *)

--- a/patches/boost-1_68_0/boost-1_68_0.patch
+++ b/patches/boost-1_68_0/boost-1_68_0.patch
@@ -14,6 +14,22 @@ diff -u -r boost_1_68_0.orig/boost/config/user.hpp boost_1_68_0/boost/config/use
  // define this to locate a compiler config file:
  // #define BOOST_COMPILER_CONFIG <myheader>
  
+diff -u -r boost_1_68_0.orig/boost/asio/detail/config.hpp boost_1_68_0/boost/asio/detail/config.hpp
+--- boost_1_68_0.orig/boost/asio/detail/config.hpp  2018-08-01 22:50:46.000000000 +0200
++++ boost_1_68_0/boost/asio/detail/config.hpp   2018-09-19 12:39:56.000000000 +0200
+@@ -804,7 +804,11 @@
+ #  if defined(__clang__)
+ #   if (__cplusplus >= 201402)
+ #    if __has_include(<experimental/string_view>)
+-#     define BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
++#     if __clang_major__ >= 7
++#      undef BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW
++#     else
++#      define BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
++#     endif // __clang_major__ >= 7
+ #    endif // __has_include(<experimental/string_view>)
+ #   endif // (__cplusplus >= 201402)
+ #  endif // defined(__clang__)
 diff -u -r boost_1_68_0.orig/boost/system/error_code.hpp boost_1_68_0/boost/system/error_code.hpp
 --- boost_1_68_0.orig/boost/system/error_code.hpp	2018-08-01 22:50:53.000000000 +0200
 +++ boost_1_68_0/boost/system/error_code.hpp	2018-08-27 15:44:29.000000000 +0200


### PR DESCRIPTION
I tested this successfully with Boost 1.68.0 and NDK r18 on a macOS host.