### PR TITLE
Add Support for NDK r17c

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -294,7 +294,7 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/arm-linux-androideabi-g++
 		TOOLSET=gcc-androidR8e
 		;;
-	"16.0"|"16.1"|"17.1"|"18.0")
+	"16.0"|"16.1"|"17.1"|"17.2"|"18.0")
 		TOOLCHAIN=${TOOLCHAIN:-llvm}
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
@@ -314,7 +314,7 @@ if [ -z "${ARCHLIST}" ]; then
 
     case "$NDK_RN" in
       # NDK 17+: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
-      "17.1"|"18.0")
+      "17.1"|"17.2"|"18.0")
         ARCHLIST="arm64-v8a armeabi-v7a x86 x86_64"
         ;;
       *)


### PR DESCRIPTION
I also tested building Boost 1.68.0 with NDK r16b, r17b, r17c and r18 using Travis:
https://travis-ci.org/Manromen/Boost-for-Android/builds/432515069

I have artifacts for these builds in my fork:
https://github.com/Manromen/Boost-for-Android/releases/tag/Boost-1.68.0