### PR TITLE
Add Boost 1.67 Support for NDK r18

### DIFF
--- a/patches/boost-1_67_0/boost-1_67_0.patch
+++ b/patches/boost-1_67_0/boost-1_67_0.patch
@@ -1,6 +1,22 @@
+diff -u -r boost_1_67_0.orig/boost/asio/detail/config.hpp boost_1_67_0/boost/asio/detail/config.hpp
+--- boost_1_67_0.orig/boost/asio/detail/config.hpp	2018-10-08 16:04:37.000000000 -0400
++++ boost_1_67_0/boost/asio/detail/config.hpp	2018-10-08 16:08:24.000000000 -0400
+@@ -804,7 +804,11 @@
+ #  if defined(__clang__)
+ #   if (__cplusplus >= 201402)
+ #    if __has_include(<experimental/string_view>)
+-#     define BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
++#     if __clang_major__ >= 7
++#      undef BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW
++#     else
++#      define BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
++#     endif // __clang_major__ >= 7
+ #    endif // __has_include(<experimental/string_view>)
+ #   endif // (__cplusplus >= 201402)
+ #  endif // defined(__clang__)
 diff -u -r boost_1_67_0.orig/boost/config/user.hpp boost_1_67_0/boost/config/user.hpp
---- boost_1_67_0.orig/boost/config/user.hpp	2018-04-27 17:32:47.000000000 -0400
-+++ boost_1_67_0/boost/config/user.hpp	2018-04-27 17:34:24.000000000 -0400
+--- boost_1_67_0.orig/boost/config/user.hpp	2018-10-08 16:04:36.000000000 -0400
++++ boost_1_67_0/boost/config/user.hpp	2018-10-08 16:06:05.000000000 -0400
 @@ -13,6 +13,12 @@
  //  configuration policy:
  //
@@ -15,8 +31,8 @@ diff -u -r boost_1_67_0.orig/boost/config/user.hpp boost_1_67_0/boost/config/use
  // #define BOOST_COMPILER_CONFIG <myheader>
  
 diff -u -r boost_1_67_0.orig/boost/system/error_code.hpp boost_1_67_0/boost/system/error_code.hpp
---- boost_1_67_0.orig/boost/system/error_code.hpp	2018-04-27 17:32:49.000000000 -0400
-+++ boost_1_67_0/boost/system/error_code.hpp	2018-04-27 17:34:24.000000000 -0400
+--- boost_1_67_0.orig/boost/system/error_code.hpp	2018-10-08 16:04:38.000000000 -0400
++++ boost_1_67_0/boost/system/error_code.hpp	2018-10-08 16:06:05.000000000 -0400
 @@ -17,6 +17,7 @@
  #include <boost/assert.hpp>
  #include <boost/noncopyable.hpp>
@@ -26,8 +42,8 @@ diff -u -r boost_1_67_0.orig/boost/system/error_code.hpp boost_1_67_0/boost/syst
  #include <string>
  #include <stdexcept>
 diff -u -r boost_1_67_0.orig/boost/thread/detail/config.hpp boost_1_67_0/boost/thread/detail/config.hpp
---- boost_1_67_0.orig/boost/thread/detail/config.hpp	2018-04-27 17:32:52.000000000 -0400
-+++ boost_1_67_0/boost/thread/detail/config.hpp	2018-04-27 17:36:44.000000000 -0400
+--- boost_1_67_0.orig/boost/thread/detail/config.hpp	2018-10-08 16:04:40.000000000 -0400
++++ boost_1_67_0/boost/thread/detail/config.hpp	2018-10-08 16:06:05.000000000 -0400
 @@ -417,6 +417,11 @@
    #define BOOST_THREAD_INTERNAL_CLOCK_IS_MONO
  #elif defined(BOOST_THREAD_CHRONO_MAC_API)
@@ -41,8 +57,8 @@ diff -u -r boost_1_67_0.orig/boost/thread/detail/config.hpp boost_1_67_0/boost/t
    #include <time.h> // check for CLOCK_MONOTONIC
    #if defined(CLOCK_MONOTONIC)
 diff -u -r boost_1_67_0.orig/libs/filesystem/src/operations.cpp boost_1_67_0/libs/filesystem/src/operations.cpp
---- boost_1_67_0.orig/libs/filesystem/src/operations.cpp	2018-04-27 17:33:02.000000000 -0400
-+++ boost_1_67_0/libs/filesystem/src/operations.cpp	2018-04-27 17:34:24.000000000 -0400
+--- boost_1_67_0.orig/libs/filesystem/src/operations.cpp	2018-10-08 16:04:50.000000000 -0400
++++ boost_1_67_0/libs/filesystem/src/operations.cpp	2018-10-08 16:06:05.000000000 -0400
 @@ -207,6 +207,21 @@
  
  # if defined(BOOST_POSIX_API)


### PR DESCRIPTION
Boost 1.67 wasn't building for NDK r18. Now it is following this patch.