### PR TITLE
Add Drone CI configuration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,8 @@
+kind: pipeline
+name: default
+
+steps:
+- name: build
+  image: jhasse/android-ndk:r19b
+  commands:
+  - ./build-android.sh $ANDROID_HOME/ndk-bundle | grep -v '^common.copy'


### PR DESCRIPTION
When the repository is activated at https://cloud.drone.io, this will check every commit and look like this: https://cloud.drone.io/jhasse/Boost-for-Android

It should also test PRs and show the status on GitHub.

I've filtered the `common.copy` lines with grep as the output would otherwise exceed the maximum.