### PR TITLE
Allow out of source builds and target API selection

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -424,7 +424,7 @@ then
 
   # Apply patches to boost
   BOOST_VER=${BOOST_VER1}_${BOOST_VER2}_${BOOST_VER3}
-  PATCH_BOOST_DIR=$PROGDIR/patches/boost-${BOOST_VER}
+  PATCH_BOOST_DIR="$SCRIPTDIR/patches/boost-${BOOST_VER}"
 
   if [ "$TOOLSET" = "clang" ]; then
       cp "$SCRIPTDIR"/configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}.jam $BOOST_DIR/tools/build/src/user-config.jam || exit 1

--- a/build-android.sh
+++ b/build-android.sh
@@ -20,8 +20,10 @@
 # Build boost for android completly. It will download boost 1.45.0
 # prepare the build system and finally build it for android
 
+SCRIPTDIR="$(cd "$(dirname "$0")"; pwd)"
+
 # Add common build methods
-. `dirname $0`/build-common.sh
+. "$SCRIPTDIR"/build-common.sh
 
 # -----------------------
 # Command line arguments
@@ -425,19 +427,19 @@ then
   PATCH_BOOST_DIR=$PROGDIR/patches/boost-${BOOST_VER}
 
   if [ "$TOOLSET" = "clang" ]; then
-      cp configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}.jam $BOOST_DIR/tools/build/src/user-config.jam || exit 1
-      for FILE in configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-*.jam; do
-          ARCH="`echo $FILE | sed s%configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-%% | sed s/[.]jam//`"
+      cp "$SCRIPTDIR"/configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}.jam $BOOST_DIR/tools/build/src/user-config.jam || exit 1
+      for FILE in "$SCRIPTDIR"/configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-*.jam; do
+          ARCH="`echo $FILE | sed s%$SCRIPTDIR/configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-%% | sed s/[.]jam//`"
           if [ "$ARCH" = "common" ]; then
               continue
           fi
           JAMARCH="`echo ${ARCH} | tr -d '_-'`" # Remove all dashes, bjam does not like them
-          sed "s/%ARCH%/${JAMARCH}/g" configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-common.jam >> $BOOST_DIR/tools/build/src/user-config.jam || exit 1
-          cat configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-$ARCH.jam >> $BOOST_DIR/tools/build/src/user-config.jam || exit 1
+          sed "s/%ARCH%/${JAMARCH}/g" "$SCRIPTDIR"/configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-common.jam >> $BOOST_DIR/tools/build/src/user-config.jam || exit 1
+          cat "$SCRIPTDIR"/configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}-$ARCH.jam >> $BOOST_DIR/tools/build/src/user-config.jam || exit 1
           echo ';' >> $BOOST_DIR/tools/build/src/user-config.jam || exit 1
       done
   else
-      cp configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}.jam $BOOST_DIR/tools/build/v2/user-config.jam || exit 1
+      cp "$SCRIPTDIR"/configs/user-config-${CONFIG_VARIANT}-${BOOST_VER}.jam $BOOST_DIR/tools/build/v2/user-config.jam || exit 1
   fi
 
   for dir in $PATCH_BOOST_DIR; do

--- a/build-android.sh
+++ b/build-android.sh
@@ -134,6 +134,13 @@ do_arch () {
   for ARCH in $(echo $1 | tr ',' '\n') ; do ARCHLIST="$ARCH ${ARCHLIST}"; done
 }
 
+ANDROID_TARGET=21
+register_option "--target-version=<version>" select_target_version \
+                "Select Android's target version" "$ANDROID_TARGET"
+select_target_version () {
+    ANDROID_TARGET="$1"
+}
+
 WITH_ICONV=
 register_option "--with-iconv" do_with_iconv "Build iconv and icu libaries, for boost-locale"
 do_with_iconv () {
@@ -507,6 +514,7 @@ echo "Building boost for android for $ARCH"
   export AndroidBinariesPath=`dirname $CXXPATH`
   export PATH=$AndroidBinariesPath:$PATH
   export AndroidNDKRoot=$AndroidNDKRoot
+  export AndroidTargetVersion="$ANDROID_TARGET"
   export NO_BZIP2=1
   export PlatformOS=$PlatformOS
 

--- a/configs/user-config-ndk19-1_70_0-common.jam
+++ b/configs/user-config-ndk19-1_70_0-common.jam
@@ -3,9 +3,10 @@
 
 using clang : %ARCH%
 :
-$(AndroidCompiler_%ARCH%)
+$(AndroidCompiler)
 :
 <archiver>$(AndroidBinariesPath)/llvm-ar
+<compileflags>--target=$(AndroidTarget_%ARCH%)
 <compileflags>-fPIC
 <compileflags>-ffunction-sections
 <compileflags>-fdata-sections

--- a/configs/user-config-ndk19-1_70_0.jam
+++ b/configs/user-config-ndk19-1_70_0.jam
@@ -40,8 +40,11 @@
 import os ;
 local AndroidNDKRoot = [ os.environ AndroidNDKRoot ] ;
 local AndroidBinariesPath = [ os.environ AndroidBinariesPath ] ;
+local AndroidTargetVersion = [ os.environ AndroidTargetVersion ] ;
 
-local AndroidCompiler_arm64v8a = $(AndroidBinariesPath)/aarch64-linux-android21-clang++ ;
-local AndroidCompiler_armeabiv7a = $(AndroidBinariesPath)/armv7a-linux-androideabi16-clang++ ;
-local AndroidCompiler_x86 = $(AndroidBinariesPath)/i686-linux-android16-clang++ ;
-local AndroidCompiler_x8664 = $(AndroidBinariesPath)/x86_64-linux-android21-clang++ ;
+local AndroidCompiler = $(AndroidBinariesPath)/clang++ ;
+
+local AndroidTarget_arm64v8a = aarch64-linux-android$(AndroidTargetVersion) ;
+local AndroidTarget_armeabiv7a = armv7a-linux-android$(AndroidTargetVersion) ;
+local AndroidTarget_x86 = i686-linux-android$(AndroidTargetVersion) ;
+local AndroidTarget_x8664 = x86_64-linux-android$(AndroidTargetVersion) ;

--- a/patches/boost-1_70_0/boost-1.70.0.patch
+++ b/patches/boost-1_70_0/boost-1.70.0.patch
@@ -66,6 +66,29 @@ diff -u -r boost_1_70_0.orig/libs/filesystem/src/operations.cpp boost_1_70_0/lib
  typedef int err_t;
  
  //  POSIX uses a 0 return to indicate success
+diff -u -r boost_1_70_0.orig/libs/filesystem/src/path.cpp boost_1_70_0/libs/filesystem/src/path.cpp
+--- boost_1_70_0.orig/libs/filesystem/src/path.cpp	2019-06-11 08:43:27.922127113 +0200
++++ boost_1_70_0/libs/filesystem/src/path.cpp	2019-06-11 08:47:45.972182953 +0200
+@@ -38,7 +38,8 @@
+ # include "windows_file_codecvt.hpp"
+ # include <windows.h>
+ #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) \
+- || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__)
++ || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) \
++ || defined(__ANDROID__)
+ # include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
+ #endif
+ 
+@@ -856,7 +857,8 @@
+     std::locale global_loc = std::locale();
+     return std::locale(global_loc, new windows_file_codecvt);
+ # elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) \
+-  || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__)
++  || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) \
++  || defined(__ANDROID__)
+     // "All BSD system functions expect their string parameters to be in UTF-8 encoding
+     // and nothing else." See
+     // http://developer.apple.com/mac/library/documentation/MacOSX/Conceptual/BPInternational/Articles/FileEncodings.html
 diff -u -r boost_1_70_0.orig/tools/build/src/tools/common.jam boost_1_70_0/tools/build/src/tools/common.jam
 --- boost_1_70_0.orig/tools/build/src/tools/common.jam	2019-04-09 21:36:57.000000000 +0200
 +++ boost_1_70_0/tools/build/src/tools/common.jam	2019-05-10 14:40:06.000000000 +0200


### PR DESCRIPTION
Please merge these commits enabling the following features

- allow to launch the `build-android.sh` script from any directory,
- add a command line option to select the target Android API (i.e. android-19, android-21, etc.)