### PR TITLE
Build boost with python

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -341,7 +341,7 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
 		;;
-	"19.0"|"19.1"|"19.2"|"20.0"|"20.1")
+	"19.0"|"19.1"|"19.2"|"20.0"|"20.1"|"21.0")
 		TOOLCHAIN=${TOOLCHAIN:-llvm}
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
@@ -362,7 +362,7 @@ if [ -z "${ARCHLIST}" ]; then
 
     case "$NDK_RN" in
       # NDK 17+: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
-      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1")
+      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1"|"21.0")
         ARCHLIST="arm64-v8a armeabi-v7a x86 x86_64"
         ;;
       *)

--- a/configs/user-config-python.jam
+++ b/configs/user-config-python.jam
@@ -1,0 +1,6 @@
+using python
+    : %PYTHON_VERSION%  # version
+    : %PYTHON_INSTALL_DIR%/bin/python  # cmd-or-prefix
+    : %PYTHON_INSTALL_DIR%/include/python%PYTHON_VERSION%m # includes
+    : %PYTHON_INSTALL_DIR%/lib # libraries
+    ;


### PR DESCRIPTION
Fixes #188 

Adds option `--with-python=<python-path>` where `python-path` is a python installation directory from https://github.com/python-cmake-buildsystem/python-cmake-buildsystem for chosen architecture.