### PR TITLE
GitHub Actions CI on MacOS and Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,19 +31,15 @@ jobs:
         echo "::set-env name=NDK_ROOT::$NDK_ROOT"
         export NUM_CPU=`python -c 'import multiprocessing as mp; print(mp.cpu_count())'`
         echo "::set-env name=NUM_CPU::$NUM_CPU"
-
-        ls -alF $NDK_ROOT/platforms/
-        if [ -f "$NDK_ROOT/RELEASE.TXT" ]; then
-            echo $NDK_ROOT/RELEASE.TXT
-            cat  $NDK_ROOT/RELEASE.TXT
-        elif [ -f "$NDK_ROOT/source.properties" ]; then
-            echo $NDK_ROOT/source.properties
-            cat  $NDK_ROOT/source.properties
-        fi
-
         set
         mkdir -p bins/${{ matrix.variation }}
         mkdir -p logs/${{ matrix.variation }}
+    - name: Install dependencies (MacOS))
+      run: |
+        brew install android-ndk
+        export NDK_ROOT="$(brew --prefix)/share/android-ndk"
+        echo "::set-env name=NDK_ROOT::$NDK_ROOT"
+      if: matrix.os != 'windows-latest'
     - name: Build Boost for Android on ${{ matrix.variation }}
       run: ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
       if: matrix.os != 'windows-latest'
@@ -53,7 +49,7 @@ jobs:
     - name: Prepare Binaries
       run: |
         set -x
-        if [ -d build/out ]; then mv build/out/* ${GITHUB_WORKSPACE}/bins/${{ matrix.variation }}/; fi
+        mv build/out/* ${GITHUB_WORKSPACE}/bins/${{ matrix.variation }}/ || true
         # Get rid of boost include directory cause it takes a long time to pack and upload (~20 min)
         find ${GITHUB_WORKSPACE}/bins/${{ matrix.variation }} -type d -name "include" -exec rm -rf {} +
         ls -alFR ${GITHUB_WORKSPACE}/bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies (MacOS))
       run: |
         brew update
-        brew install android-ndk
+        brew cask install android-ndk
         export NDK_ROOT="$(brew --prefix)/share/android-ndk"
         echo "::set-env name=NDK_ROOT::$NDK_ROOT"
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest,windows-latest,macos-latest]
+        include:
+          # includes a new variable of 'variation' for each host os
+          - os: ubuntu-latest
+            variation: linux
+          - os: windows-latest
+            variation: windows
+          - os: macos-latest
+            variation: mac
+        exclude:
+          # disable some matrix combinations if needed
+          - os: windows-latest
+          - os: macos-latest
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Setup Environment Variables
+      run: |
+        set -x
+        export NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+        echo "::set-env name=NDK_ROOT::$NDK_ROOT"
+        export NUM_CPU=`python -c 'import multiprocessing as mp; print(mp.cpu_count())'`
+        echo "::set-env name=NUM_CPU::$NUM_CPU"
+
+        ls -alF $NDK_ROOT/platforms/
+        if [ -f "$NDK_ROOT/RELEASE.TXT" ]; then
+            echo $NDK_ROOT/RELEASE.TXT
+            cat  $NDK_ROOT/RELEASE.TXT
+        elif [ -f "$NDK_ROOT/source.properties" ]; then
+            echo $NDK_ROOT/source.properties
+            cat  $NDK_ROOT/source.properties
+        fi
+
+        set
+        mkdir -p bins/${{ matrix.variation }}
+        mkdir -p logs/${{ matrix.variation }}
+    - name: Install Dependencies (Linux)
+      run: |
+        set -x
+        sudo apt-get update
+        sudo apt-get install ia32-libs
+      if: matrix.os == 'ubuntu-latest'
+    - name: Build Boost for Android on ${{ matrix.variation }}
+      run: |
+        set -x
+        ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}"
+      if: matrix.variation == 'linux'
+    - name: Prepare Binaries
+      run: |
+        set -x
+        if [ -d build/out ]; then mv build/out/* ${GITHUB_WORKSPACE}/bins/${{ matrix.variation }}/; fi
+        ls -alFR ${GITHUB_WORKSPACE}/bins
+      if: always()
+    - name: Upload Binaries
+      uses: actions/upload-artifact@v1
+      with:
+        name: binaries
+        path: ./bins
+      if: always()
+    - name: Prepare Logs
+      run: |
+        set -x
+        mv logs/*.log ${GITHUB_WORKSPACE}/logs/${{ matrix.variation }}/;
+        ls -alFR ${GITHUB_WORKSPACE}/logs
+      if: always()
+    - name: Upload Logs
+      uses: actions/upload-artifact@v1
+      with:
+        name: logs
+        path: ./logs
+      if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,6 @@ jobs:
         set
         mkdir -p bins/${{ matrix.variation }}
         mkdir -p logs/${{ matrix.variation }}
-    - name: Install Dependencies (Linux)
-      run: |
-        set -x
-        sudo apt-get update
-        sudo apt-get install ia32-libs
-      if: matrix.os == 'ubuntu-latest'
     - name: Build Boost for Android on ${{ matrix.variation }}
       run: |
         set -x
@@ -74,7 +68,7 @@ jobs:
     - name: Prepare Logs
       run: |
         set -x
-        mv logs/*.log ${GITHUB_WORKSPACE}/logs/${{ matrix.variation }}/;
+        mv logs/*.log ${GITHUB_WORKSPACE}/logs/${{ matrix.variation }}/ || true
         ls -alFR ${GITHUB_WORKSPACE}/logs
       if: always()
     - name: Upload Logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ jobs:
             variation: windows
           - os: macos-latest
             variation: mac
-        exclude:
-          # disable some matrix combinations if needed
-          - os: windows-latest
-          - os: macos-latest
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -49,14 +45,17 @@ jobs:
         mkdir -p bins/${{ matrix.variation }}
         mkdir -p logs/${{ matrix.variation }}
     - name: Build Boost for Android on ${{ matrix.variation }}
-      run: |
-        set -x
-        ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
-      if: matrix.variation == 'linux'
+      run: ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
+      if: matrix.os != 'windows-latest'
+    - name: Build Boost for Android on ${{ matrix.variation }}
+      run: build-android.bat  --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
+      if: matrix.os == 'windows-latest'
     - name: Prepare Binaries
       run: |
         set -x
         if [ -d build/out ]; then mv build/out/* ${GITHUB_WORKSPACE}/bins/${{ matrix.variation }}/; fi
+        # Get rid of boost include directory cause it takes a long time to pack and upload (~20 min)
+        find ${GITHUB_WORKSPACE}/bins/${{ matrix.variation }} -type d -name "include" -exec rm -rf {} +
         ls -alFR ${GITHUB_WORKSPACE}/bins
       if: always()
     - name: Upload Binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Build Boost for Android on ${{ matrix.variation }}
       run: |
         set -x
-        ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}"
+        ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
       if: matrix.variation == 'linux'
     - name: Prepare Binaries
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         echo "::set-env name=NDK_ROOT::$NDK_ROOT"
       if: matrix.os == 'macos-latest'
     - name: Build Boost for Android on ${{ matrix.variation }}
-      run: CXXFLAGS="-std=c++14" ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a --with-libraries=atomic,system "${NDK_ROOT}"
+      run: CXXFLAGS="-std=c++14" ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
     - name: Prepare Binaries
       run: |
         set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         echo "::set-env name=NDK_ROOT::$NDK_ROOT"
       if: matrix.os == 'macos-latest'
     - name: Build Boost for Android on ${{ matrix.variation }}
-      run: CXXFLAGS="-std=c++11" ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,system,thread "${NDK_ROOT}"
+      run: CXXFLAGS="-std=c++14" ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a --with-libraries=atomic,system "${NDK_ROOT}"
     - name: Prepare Binaries
       run: |
         set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest,windows-latest,macos-latest]
+        os: [ubuntu-latest,macos-latest]
         include:
           # includes a new variable of 'variation' for each host os
           - os: ubuntu-latest
             variation: linux
-          - os: windows-latest
-            variation: windows
           - os: macos-latest
             variation: mac
       fail-fast: false
@@ -36,16 +34,13 @@ jobs:
         mkdir -p logs/${{ matrix.variation }}
     - name: Install dependencies (MacOS))
       run: |
+        brew update
         brew install android-ndk
         export NDK_ROOT="$(brew --prefix)/share/android-ndk"
         echo "::set-env name=NDK_ROOT::$NDK_ROOT"
-      if: matrix.os != 'windows-latest'
+      if: matrix.os == 'macos-latest'
     - name: Build Boost for Android on ${{ matrix.variation }}
       run: ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
-      if: matrix.os != 'windows-latest'
-    - name: Build Boost for Android on ${{ matrix.variation }}
-      run: build-android.bat  --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
-      if: matrix.os == 'windows-latest'
     - name: Prepare Binaries
       run: |
         set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         echo "::set-env name=NDK_ROOT::$NDK_ROOT"
       if: matrix.os == 'macos-latest'
     - name: Build Boost for Android on ${{ matrix.variation }}
-      run: ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_ROOT}"
+      run: CXXFLAGS="-std=c++11" ./build-android.sh --boost=1.70.0 --arch=armeabi-v7a,x86 --with-libraries=atomic,system,thread "${NDK_ROOT}"
     - name: Prepare Binaries
       run: |
         set -x

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Boost for Android
+# Boost for Android [![Build Status: GitHub Actions](workflows/CI/badge.svg)](actions)
 Boost for android is a set of tools to compile the main part of the [Boost C++ Libraries](http://www.boost.org/) for the Android platform.
 
 Currently supported boost versions are 1.45.0, 1.48.0, 1.49.0, 1.53.0, 1.54.0, 1.55.0, 1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0 and 1.70.0.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Boost for Android [![Build Status: GitHub Actions](https://github.com/solodon4/Boost-for-Android/workflows/CI/badge.svg)](https://github.com/solodon4/Boost-for-Android/actions)
+# Boost for Android [![Build Status: GitHub Actions](https://github.com/moritz-wundke/Boost-for-Android/workflows/CI/badge.svg)](https://github.com/moritz-wundke/Boost-for-Android/actions)
 Boost for android is a set of tools to compile the main part of the [Boost C++ Libraries](http://www.boost.org/) for the Android platform.
 
 Currently supported boost versions are 1.45.0, 1.48.0, 1.49.0, 1.53.0, 1.54.0, 1.55.0, 1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0 and 1.70.0.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Boost for Android [![Build Status: GitHub Actions](workflows/CI/badge.svg)](actions)
+# Boost for Android [![Build Status: GitHub Actions](https://github.com/solodon4/Boost-for-Android/workflows/CI/badge.svg)](https://github.com/solodon4/Boost-for-Android/actions)
 Boost for android is a set of tools to compile the main part of the [Boost C++ Libraries](http://www.boost.org/) for the Android platform.
 
 Currently supported boost versions are 1.45.0, 1.48.0, 1.49.0, 1.53.0, 1.54.0, 1.55.0, 1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0 and 1.70.0.

--- a/build-android.sh
+++ b/build-android.sh
@@ -362,7 +362,7 @@ if [ -z "${ARCHLIST}" ]; then
 
     case "$NDK_RN" in
       # NDK 17+: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
-      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1""|"21.0")
+      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1"|"21.0")
         ARCHLIST="arm64-v8a armeabi-v7a x86 x86_64"
         ;;
       *)

--- a/build-android.sh
+++ b/build-android.sh
@@ -341,7 +341,7 @@ case "$NDK_RN" in
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
 		;;
-	"19.0"|"19.1"|"19.2"|"20.0"|"20.1")
+	"19.0"|"19.1"|"19.2"|"20.0"|"20.1"|"21.0")
 		TOOLCHAIN=${TOOLCHAIN:-llvm}
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
@@ -362,7 +362,7 @@ if [ -z "${ARCHLIST}" ]; then
 
     case "$NDK_RN" in
       # NDK 17+: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
-      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1")
+      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1""|"21.0")
         ARCHLIST="arm64-v8a armeabi-v7a x86 x86_64"
         ;;
       *)


### PR DESCRIPTION
This pull request integrates GitHub Actions for continuous integration of Boost-for-Android. Currently it only runs build of several libraries: atomic, random, date_time, filesystem, system, thread, chrono for starters but I'd leave it to the authors to decide what they want to test eventually. Build matrix only includes macOS and Ubuntu runners right now because the script works for both of them without much changes. Adding Windows shouldn't be much of a problem, although it will require separate case. I'd rather wait till Microsoft adds support for WSL in GitHub Actions runner to keep the same script everywhere.

Change in the README.md includes a badge for the status of the build, but since it is already pointing to your repository, you won't see it in my latest build in the fork. They don't seem to be supporting fork-independent badges, so I had to hardcode it to the origin. Once this pull request completes, you'll see the badge. It was working properly on my fork before last commit.

The pull request also updates your script to recognize NDK 21.0 since that is the NDK available on GitHub Actions runners.

I had to delay this pull request for few weeks because GitHub Actions runner for MacOS had a [[BUG] MacOS runner takes 6 hours to run a 1 minute workflow](https://github.community/t5/GitHub-Actions/BUG-MacOS-runner-takes-6-hours-to-run-a-1-minute-workflow/td-p/46053) I filed, which is also tracked by their ticked [MacOS runner takes 6 hours to run a 1 minute workflow #430](https://github.com/actions/virtual-environments/issues/430). Yesterday they reported the issue has been resolved and I have validated it on my fork, so it should be good to go now.