### PR TITLE
Build more architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     strategy:
       matrix:
-        boost_version: [1.70.0]
-        abi: [armeabi-v7a]
+        boost_version: [1.70.0,1.73.0]
+        abi: [armeabi-v7a,arm64-v8a,x86,x86_64]
         os: [ubuntu-latest,macos-latest]
         include:
           # includes a new variable of 'variation' for each host os


### PR DESCRIPTION
Now you see **a lot of builds**.
Multiplied by crap build https://github.com/moritz-wundke/Boost-for-Android/commit/cb918850cc8e3fb45a864e8342ff64ff4e07db51 and multiplied by declined OS https://github.com/moritz-wundke/Boost-for-Android/pull/209