### PR TITLE
Support Android NDK r22b

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -398,7 +398,7 @@ case "$NDK_RN" in
 		TOOLSET=clang
 		CONFIG_VARIANT=ndk19
 		;;
-	"23.0"|"23.1"|"25.0"|"25.1")
+	"22.1"|"23.0"|"23.1"|"25.0"|"25.1")
 		TOOLCHAIN=${TOOLCHAIN:-llvm}
 		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 		TOOLSET=clang
@@ -419,7 +419,7 @@ if [ -z "${ARCHLIST}" ]; then
 
     case "$NDK_RN" in
       # NDK 17+: Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed.
-      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1"|"21.0"|"21.1"|"21.2"|"21.3"|"21.4"|"23.0"|"23.1"|"25.0"|"25.1")
+      "17.1"|"17.2"|"18.0"|"18.1"|"19.0"|"19.1"|"19.2"|"20.0"|"20.1"|"21.0"|"21.1"|"21.2"|"21.3"|"21.4"|"22.1"|"23.0"|"23.1"|"25.0"|"25.1")
         ARCHLIST="arm64-v8a armeabi-v7a x86 x86_64"
         ;;
       *)


### PR DESCRIPTION
Hi!

This patch is to upstream support for NDK r22b, which we use in Krita for our nightly builds.

Source MR: https://invent.kde.org/graphics/krita/-/merge_requests/1594

cc @sh-zam