### PR TITLE
Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Windows:
 ```
 build-android.bat $(NDK_ROOT)
 ```
-NOTE: Do not forget to replace backslash with slashes in $(NDK_ROOT). For example set $(NDK_ROOT) to D:/android-ndk-r8e instead of D:\android-ndk-r8e
+NOTE: Do not forget to replace backslash with slashes in `$(NDK_ROOT)`. For example set `$(NDK_ROOT)` to D:/android-ndk-r8e instead of D:\android-ndk-r8e
 
 On windows you will need MSYS to be able to launch the corresponding bat files (http://www.mingw.org/wiki/MSYS).
 


### PR DESCRIPTION
GitHub's website is interpreting the `$(NDK_ROOT)...$` section as a MathJax formula, so wrap those parts in inline code blocks to force them to be displayed correctly.